### PR TITLE
Uso del modulo "Client" 

### DIFF
--- a/lib/compropago.rb
+++ b/lib/compropago.rb
@@ -5,6 +5,7 @@ require "active_rest_client"
 require "compropago/configuration"
 
 module Compropago
+  autoload :Client, 'compropago/client'
   autoload :Base, 'compropago/base'
   autoload :Charge, 'compropago/charge'
   autoload :SMS, 'compropago/sms'

--- a/lib/compropago/client.rb
+++ b/lib/compropago/client.rb
@@ -11,7 +11,7 @@ module Compropago
 
   	  #defaults
   	  options[:base_uri] ||= BASE_URI
-  	  @base_uri = options[:base_uri]	
+  	  @base_uri = options[:base_uri]
   	end
 
   	def create_charge(product_price, product_name, customer_name, customer_email, payment_type, product_id=nil, image_url=nil)
@@ -22,17 +22,15 @@ module Compropago
   	  request = Net::HTTP::Post.new(uri.request_uri)
   	  request.basic_auth @api_key, ''
   	  params = { "product_price" => product_price,
-  	  			 "product_name" => product_name,
-  	  			 "customer_name" => customer_name,
-  	  			 "customer_email" => customer_email,
-  	  			 "payment_type" => payment_type,
-  	  			 "product_id" => product_id,
-  	  			 "image_url" => image_url,
-  	  			 "product_id" => product_id,
-  	    		 "image_url" => image_url
-  	  		  }
+  	  			     "product_name" => product_name,
+  	  			     "customer_name" => customer_name,
+  	  			     "customer_email" => customer_email,
+  	  			     "payment_type" => payment_type,
+  	  			     "product_id" => product_id,
+  	    		     "image_url" => image_url
+  	  		     }
   	  request.set_form_data(params)
-  	  response = http.request(request)
+  	  http.request(request)
   	end
 
   	def verify_charge(payment_id)
@@ -42,7 +40,7 @@ module Compropago
   	  http.verify_mode = OpenSSL::SSL::VERIFY_NONE
   	  request = Net::HTTP::Get.new(uri.request_uri)
   	  request.basic_auth @api_key, ''
-  	  response = http.request(request)
+  	  http.request(request)
   	end
 
   	def send_payment_instructions(payment_id, customer_phone, customer_company_phone)
@@ -53,11 +51,11 @@ module Compropago
   	  request = Net::HTTP::Post.new(uri.request_uri)
   	  request.basic_auth @api_key, ''
   	  params = { "payment_id" => payment_id.to_s,
-  	  			 "customer_phone" => customer_phone.to_s,
-  	  			 "customer_company_phone" => customer_company_phone
-  	  		   }
+  	  			     "customer_phone" => customer_phone.to_s,
+  	  			     "customer_company_phone" => customer_company_phone
+  	  		     }
   	  request.set_form_data(params)
-  	  response = http.request(request)
+  	  http.request(request)
   	end
   end
 end


### PR DESCRIPTION
Este PR agrega de nuevo el modulo "Cliente" que hace las llamadas al API directamente.

Desafortunadamente no puedo utilizar la nueva versión del API (usando la clase Charge por ejemplo) porque el API key se guarda en una variable global. Mi aplicación es multitenant/multicliente y las variables globales causan problemas dado que cada uno de mis usuarios puede tener su propio API key.

También arreglé unos warnings acerca de llaves duplicadas en un Hash.

Saludos,